### PR TITLE
Winterly Paper Block

### DIFF
--- a/kubejs/data/winterly/recipes/paper_block.json
+++ b/kubejs/data/winterly/recipes/paper_block.json
@@ -1,0 +1,13 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [ "C" ],
+  "key": {
+    "C": {
+      "item": "blockus:paper_block"
+    }
+  },
+  "result": {
+    "item": "winterly:paper_block",
+    "count": 1
+  }
+}

--- a/kubejs/data/winterly/recipes/paper_block.json
+++ b/kubejs/data/winterly/recipes/paper_block.json
@@ -1,6 +1,9 @@
 {
   "type": "minecraft:crafting_shaped",
-  "pattern": [ "C" ],
+  "pattern": [
+    "CC",
+    "CC"
+  ],
   "key": {
     "C": {
       "item": "blockus:paper_block"
@@ -8,6 +11,6 @@
   },
   "result": {
     "item": "winterly:paper_block",
-    "count": 1
+    "count": 4
   }
 }


### PR DESCRIPTION
Allows conversion of Blockus Paper Block to Winterly Paper Blocks, in order to resolve a recipe conflict.
![image](https://user-images.githubusercontent.com/41505541/147677265-b48db7e3-c643-4d3d-a9de-cbd7f8137789.png)