### PR TITLE
reenables poppets and curses

### DIFF
--- a/config/bewitchment.json
+++ b/config/bewitchment.json
@@ -1,9 +1,6 @@
 {
-  "disabledPoppets": [
-    "bewitchment:voodoo_poppet",
-    "bewitchment:vampiric_poppet"
-  ],
-  "enableCurses": false,
+  "disabledPoppets": [],
+  "enableCurses": true,
   "altarDistributionRadius": 24,
   "generateSilver": false,
   "generateSalt": false,


### PR DESCRIPTION
Curses and voodoo poppets, two integral parts of the Bewitchment mod, are currently disabled, taking the fun out of interacting with other people using the mod. Poppets and curses cannot kill directly; they serve as an annoyance which can be fairly simply reversed or prevented. Without these features, the bewitchment mod loses both its charm and its purpose: to wield morally grey magics, make pacts with devils, and threaten people. It's just a bloated alchemy mod without being able to affect the world.