### PR TITLE
startserver.sh curl needs to follow redirects

### DIFF
--- a/server_files/startserver.sh
+++ b/server_files/startserver.sh
@@ -27,7 +27,7 @@ fi
 			which curl >> /dev/null
 			if [ $? -eq 0 ]; then
 				echo "DEBUG: (curl) Downloading ${URL}"
-				curl -o serverstarter-2.1.1.jar "${URL}"
+				curl -L -o serverstarter-2.1.1.jar "${URL}"
 			else
 				echo "Neither wget or curl were found on your system. Please install one and try again"
          fi


### PR DESCRIPTION
Without this addition of '-L', curl fails to properly fetch the
serverstarter jar and everything grinds to a halt.

Signed-off-by: Jim Ramsay <i.am@jimramsay.com>
