### PR TITLE
Completely disable dismantling table

### DIFF
--- a/kubejs/server_scripts/removals.js
+++ b/kubejs/server_scripts/removals.js
@@ -103,3 +103,25 @@ onEvent('recipes', (event) => {
               event.remove({ id: 'indrev:shapeless/' + plates + '_plate_from_hammer' });
           });
 });
+
+onEvent('block.place', event => {
+  if (event.block.id == "twilightforest:uncrafting_table") {
+    event.cancel()
+  }
+});
+
+onEvent('block.break', event => {
+  if (event.block.id == "twilightforest:uncrafting_table") {
+    event.cancel()
+  }
+});
+
+onEvent('block.right_click', event => {
+  if (event.block.id == "twilightforest:uncrafting_table") {
+    event.cancel()
+  }
+});
+
+onEvent('recipes', event => {
+  event.remove({input:"twilightforest:uncrafting_table"})
+});


### PR DESCRIPTION
Because uncrafting_table can still be found in the world even if the setting is turned off, and then the player will cause the game to crash when placing items in it